### PR TITLE
add: feature/transactionBoundary

### DIFF
--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/transaction/TransactionBoundary.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/transaction/TransactionBoundary.kt
@@ -1,33 +1,8 @@
 package com.mosa.office.kintai.application.transaction
 
-import org.springframework.beans.factory.getBean
-import org.springframework.context.ApplicationContext
-import org.springframework.beans.BeansException
-import org.springframework.context.ApplicationContextAware
-import org.springframework.stereotype.Component
-
-fun <T> transaction(process:() -> T):T {
-    return TransactionBoundaryProvider.getTransactionBoundary().transaction(process)
-}
-
 interface TransactionBoundary {
-    fun <T> transaction(process:() -> T):T
+    fun <T> start(process:() -> T):T
 }
 
-@Component
-class TransactionBoundaryProvider : ApplicationContextAware {
 
-    @Throws(BeansException::class)
-    override fun setApplicationContext(context: ApplicationContext) {
-        boundary = context.getBean(TransactionBoundary::class.java)
-    }
-
-    companion object {
-        private var boundary: TransactionBoundary? = null
-
-        fun getTransactionBoundary(): TransactionBoundary {
-            return boundary ?: throw Exception();
-        }
-    }
-}
 

--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/transaction/TransactionBoundary.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/transaction/TransactionBoundary.kt
@@ -1,0 +1,33 @@
+package com.mosa.office.kintai.application.transaction
+
+import org.springframework.beans.factory.getBean
+import org.springframework.context.ApplicationContext
+import org.springframework.beans.BeansException
+import org.springframework.context.ApplicationContextAware
+import org.springframework.stereotype.Component
+
+fun <T> transaction(process:() -> T):T {
+    return TransactionBoundaryProvider.getTransactionBoundary().transaction(process)
+}
+
+interface TransactionBoundary {
+    fun <T> transaction(process:() -> T):T
+}
+
+@Component
+class TransactionBoundaryProvider : ApplicationContextAware {
+
+    @Throws(BeansException::class)
+    override fun setApplicationContext(context: ApplicationContext) {
+        boundary = context.getBean(TransactionBoundary::class.java)
+    }
+
+    companion object {
+        private var boundary: TransactionBoundary? = null
+
+        fun getTransactionBoundary(): TransactionBoundary {
+            return boundary ?: throw Exception();
+        }
+    }
+}
+

--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/usecase/AddPaidUseCase.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/usecase/AddPaidUseCase.kt
@@ -1,7 +1,7 @@
 package com.mosa.office.kintai.application.usecase
 
 import com.mosa.office.kintai.application.service.UniqueIdGenerator
-import com.mosa.office.kintai.application.transaction.transaction
+import com.mosa.office.kintai.application.transaction.TransactionBoundary
 import com.mosa.office.kintai.domain.model.Paid
 import com.mosa.office.kintai.domain.model.PaidTimeType
 import com.mosa.office.kintai.domain.model.User
@@ -16,7 +16,8 @@ import java.time.LocalDate
 @Component
 class AddPaidUseCase(
     private val paidService : PaidService,
-    private val idGene : UniqueIdGenerator
+    private val idGene : UniqueIdGenerator,
+    private val transaction : TransactionBoundary
 ) {
     /**
      * @param input 追加する有給
@@ -32,7 +33,7 @@ class AddPaidUseCase(
             input.paidReason
         )
         // トランザクション境界を設定
-        transaction {
+        transaction.start {
             paidService.add(paid)
         }
         // TODO Slackへの通知

--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/usecase/AddPaidUseCase.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/usecase/AddPaidUseCase.kt
@@ -1,6 +1,7 @@
 package com.mosa.office.kintai.application.usecase
 
 import com.mosa.office.kintai.application.service.UniqueIdGenerator
+import com.mosa.office.kintai.application.transaction.transaction
 import com.mosa.office.kintai.domain.model.Paid
 import com.mosa.office.kintai.domain.model.PaidTimeType
 import com.mosa.office.kintai.domain.model.User
@@ -30,7 +31,10 @@ class AddPaidUseCase(
             user.userId,
             input.paidReason
         )
-        paidService.add(paid)
+        // トランザクション境界を設定
+        transaction {
+            paidService.add(paid)
+        }
         // TODO Slackへの通知
     }
 

--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/usecase/GetPaidListUseCase.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/usecase/GetPaidListUseCase.kt
@@ -1,5 +1,6 @@
 package com.mosa.office.kintai.application.usecase
 
+import com.mosa.office.kintai.application.transaction.transaction
 import com.mosa.office.kintai.domain.model.Paid
 import com.mosa.office.kintai.domain.model.PaidRepository
 import org.springframework.stereotype.Component
@@ -8,7 +9,10 @@ import org.springframework.stereotype.Component
 class GetPaidListUseCase(private val repository: PaidRepository) {
 
     fun getPaidList(userId:String) : List<Paid> {
-        return repository.getAllByUserId(userId);
+        // トランザクション境界を設定
+        return transaction {
+            repository.getAllByUserId(userId)
+        }
     }
 
 }

--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/usecase/GetPaidListUseCase.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/application/usecase/GetPaidListUseCase.kt
@@ -1,16 +1,19 @@
 package com.mosa.office.kintai.application.usecase
 
-import com.mosa.office.kintai.application.transaction.transaction
+import com.mosa.office.kintai.application.transaction.TransactionBoundary
 import com.mosa.office.kintai.domain.model.Paid
 import com.mosa.office.kintai.domain.model.PaidRepository
 import org.springframework.stereotype.Component
 
 @Component
-class GetPaidListUseCase(private val repository: PaidRepository) {
+class GetPaidListUseCase(
+    private val repository: PaidRepository,
+    private val transaction : TransactionBoundary
+) {
 
     fun getPaidList(userId:String) : List<Paid> {
         // トランザクション境界を設定
-        return transaction {
+        return transaction.start {
             repository.getAllByUserId(userId)
         }
     }

--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/gateway/ExposedTransactionBoundary.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/gateway/ExposedTransactionBoundary.kt
@@ -1,0 +1,13 @@
+package com.mosa.office.kintai.gateway
+
+import com.mosa.office.kintai.application.transaction.TransactionBoundary
+import org.springframework.stereotype.Component
+
+@Component
+class ExposedTransactionBoundary : TransactionBoundary {
+    override fun <T> transaction(process: () -> T): T {
+        return org.jetbrains.exposed.sql.transactions.transaction {
+            process()
+        }
+    }
+}

--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/gateway/ExposedTransactionBoundary.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/gateway/ExposedTransactionBoundary.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class ExposedTransactionBoundary : TransactionBoundary {
-    override fun <T> transaction(process: () -> T): T {
+    override fun <T> start(process: () -> T): T {
         return org.jetbrains.exposed.sql.transactions.transaction {
             process()
         }

--- a/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/gateway/PaidRepositoryImpl.kt
+++ b/mosakin-backend/src/main/kotlin/com/mosa/office/kintai/gateway/PaidRepositoryImpl.kt
@@ -17,23 +17,23 @@ import java.time.LocalDate
 @Service
 class PaidRepositoryImpl : PaidRepository {
     override fun getAllByUserId(userId: String): List<Paid> {
-        return transaction {
-            val query = PaidTable.select {
-                PaidTable.userId eq userId
-            }
-            query.map { convertToPaid(it) }
+
+        val query = PaidTable.select {
+            PaidTable.userId eq userId
         }
+        return query.map { convertToPaid(it) }
+
     }
 
     override fun add(paid: Paid) {
-        transaction {
-            PaidTable.insert {
-                it[PaidTable.userId] = paid.paidAcquisitionUserId
-                it[PaidTable.comment] = paid.paidReason
-                it[PaidTable.timeType] = toPaidTimeTypeDb[paid.paidTimeType] ?: throw Exception("予期せぬエラー")
-                it[PaidTable.acquisitionDate] = javaLocalDateToJodaDateTime(paid.paidAcquisitionDate)
-            }
+
+        PaidTable.insert {
+            it[PaidTable.userId] = paid.paidAcquisitionUserId
+            it[PaidTable.comment] = paid.paidReason
+            it[PaidTable.timeType] = toPaidTimeTypeDb[paid.paidTimeType] ?: throw Exception("予期せぬエラー")
+            it[PaidTable.acquisitionDate] = javaLocalDateToJodaDateTime(paid.paidAcquisitionDate)
         }
+
     }
 }
 


### PR DESCRIPTION
トランザクションの境界を今までリポジトリの実装内で引いていましたが、業務のトランザクションはリポジトリをまたぐのでアプリケーション層に境界を置くように変更しました。
またそれに伴い、アプリケーションが特定のトランザクション管理の実装に依存しないように抽象化しました。