### PR TITLE
WIP: add: error-box margin, errorhandler in paidlist & upadetepaid, create context

### DIFF
--- a/mosakin-frontend/src/components/atoms/toggle/index.tsx
+++ b/mosakin-frontend/src/components/atoms/toggle/index.tsx
@@ -34,10 +34,10 @@ const Label = styled.label<Labelprops>`
   color: ${({ selected }): string =>
     selected ? paletteDict.white : paletteDict.black};
   cursor: pointer;
-  :first-child {
+  :first-of-type {
     border-radius: 30px 0 0 30px;
   }
-  :last-child {
+  :last-of-type {
     border-radius: 0 30px 30px 0;
   }
   :hover {

--- a/mosakin-frontend/src/components/templates/create-page/index.tsx
+++ b/mosakin-frontend/src/components/templates/create-page/index.tsx
@@ -35,18 +35,25 @@ const ButtonArea = styled.div`
   text-align: center;
 `;
 
+const StyledErrorBoxWrapper = styled.div`
+  margin-bottom: 30px;
+`;
+
 export const CreatePage = (props: NewPaidViewModel) => (
   <OuterDiv>
     <TitleArea>
       <PageTitle title="新規申請"></PageTitle>
     </TitleArea>
+
+    <StyledErrorBoxWrapper>
+      <ErrorBox errors={props.errors} />
+    </StyledErrorBoxWrapper>
+
     {props.data.adminFlg && (
       <InnerDiv>
         <CommonUserNameArea value={props.data.userName}></CommonUserNameArea>
       </InnerDiv>
     )}
-
-    <ErrorBox errors={props.errors} />
 
     <InnerDiv>
       <DateInputArea

--- a/mosakin-frontend/src/components/templates/list-page/index.tsx
+++ b/mosakin-frontend/src/components/templates/list-page/index.tsx
@@ -6,6 +6,7 @@ import { PaidListViewModel } from "../../../models/models/paidList";
 import { PaidListHeader } from "../../organisms/paidListHeader";
 import { PaidListRows } from "../../organisms/paidListRows";
 import { PageTitle } from "../../molecules/pageTitle";
+import { ErrorBox } from "@/components/molecules/error-box";
 
 const OuterDiv = styled.div`
   width: 603px;
@@ -24,6 +25,10 @@ const TitleArea = styled.div`
 const HeaderWrapper = styled.div`
   width: 100%;
   margin-bottom: 38px;
+`;
+
+const StyledErrorBoxWrapper = styled.div`
+  margin-bottom: 30px;
 `;
 
 /**
@@ -46,6 +51,11 @@ export const PaidListTemplate: React.FC<
         <TitleArea>
           <PageTitle title="有給取得一覧"></PageTitle>
         </TitleArea>
+
+        <StyledErrorBoxWrapper>
+          <ErrorBox errors={model.data.errors} />
+        </StyledErrorBoxWrapper>
+
         <HeaderWrapper>
           <PaidListHeader {...model.data.header}></PaidListHeader>
         </HeaderWrapper>

--- a/mosakin-frontend/src/components/templates/update-page/index.tsx
+++ b/mosakin-frontend/src/components/templates/update-page/index.tsx
@@ -4,6 +4,7 @@ import { bp } from "@/common/theme";
 import { PageTitle } from "../../molecules/pageTitle";
 import { CommonUserNameArea } from "../../molecules/common-user-name-area";
 import { DateInputArea } from "../../molecules/date-input-area";
+import { ErrorBox } from "@/components/molecules/error-box";
 import { PaidTimeType } from "../../molecules/paid-time-type";
 import { PaidReasonArea } from "../../molecules/paid-reason-area";
 import { Button } from "../../atoms/button";
@@ -34,11 +35,20 @@ const ButtonArea = styled.div`
   text-align: center;
 `;
 
+const StyledErrorBoxWrapper = styled.div`
+  margin-bottom: 30px;
+`;
+
 export const UpdatePage = (props: UpdatePaidViewModel) => (
   <OuterDiv>
     <TitleArea>
       <PageTitle title="登録変更申請"></PageTitle>
     </TitleArea>
+
+    <StyledErrorBoxWrapper>
+      <ErrorBox errors={props.errors} />
+    </StyledErrorBoxWrapper>
+
     {props.data.adminFlg && (
       <InnerDiv>
         <CommonUserNameArea value={props.data.userName}></CommonUserNameArea>

--- a/mosakin-frontend/src/context/PaidContext.tsx
+++ b/mosakin-frontend/src/context/PaidContext.tsx
@@ -1,0 +1,13 @@
+import React, { useState, useEffect, useContext } from "react";
+import { PaidListItem } from "@/models/models/paidList";
+import { axios } from "@/common/api/axios";
+
+type PaidListContextValue = () => PaidListItem;
+
+export const PaidListContext = React.createContext<PaidListContextValue>(() => {
+  throw new Error("");
+});
+
+export const usePaidInfo: () => PaidListItem = () => {
+  return useContext(PaidListContext)();
+};

--- a/mosakin-frontend/src/hooks/useNewPaid.ts
+++ b/mosakin-frontend/src/hooks/useNewPaid.ts
@@ -23,39 +23,55 @@ export const useNewPaid = (): NewPaidViewModel => {
   };
   const onSubmit = () => {
     axios
-      .post(`/add`, {
-        paidAcquisitionDate: createData.dateValue,
-        paidTimeType: paidTimeValue,
-        paidReason: reasonValue
-      })
+      .post(
+        `/add`,
+        {
+          paidAcquisitionDate: createData.dateValue,
+          paidTimeType: paidTimeValue,
+          paidReason: reasonValue
+        },
+        {
+          validateStatus: function(status) {
+            return status < 500;
+          }
+        }
+      )
       .then(res => {
         // 正常に処理ができていれば業務エラーでも200で返ってくる
-        switch (res.data) {
-          case "SUCCESS":
-            setErrors([]);
-            break;
-          case "DUPLICATED":
-            setErrors([
-              {
-                content: "DUPLICATED"
-              }
-            ]);
-            break;
-          case "NOTIFICATION_FAILED":
-            setErrors([
-              {
-                content: "NOTIFICATION_FAILED"
-              }
-            ]);
-            break;
-          default:
-            // APIから返ってくるメッセージが予想外なパターン
-            setErrors([
-              {
-                content: "UNEXPECTED_ERROR"
-              }
-            ]);
-            break;
+        if (res.status === 500) {
+          setErrors([
+            {
+              content: "INTERNAL_SEWRVER_ERROR"
+            }
+          ]);
+        } else {
+          switch (res.data) {
+            case "SUCCESS":
+              setErrors([]);
+              break;
+            case "DUPLICATED":
+              setErrors([
+                {
+                  content: "DUPLICATED"
+                }
+              ]);
+              break;
+            case "NOTIFICATION_FAILED":
+              setErrors([
+                {
+                  content: "NOTIFICATION_FAILED"
+                }
+              ]);
+              break;
+            default:
+              // APIから返ってくるメッセージが予想外なパターン
+              setErrors([
+                {
+                  content: "UNEXPECTED_ERROR"
+                }
+              ]);
+              break;
+          }
         }
       })
       .catch(e => {

--- a/mosakin-frontend/src/hooks/usePaidList.ts
+++ b/mosakin-frontend/src/hooks/usePaidList.ts
@@ -22,10 +22,34 @@ export const usePaidList = (): LoadableViewModel<PaidListViewModel> => {
 
   useEffect(() => {
     axios
-      .get("/list")
+      .get("/list", {
+        validateStatus: function(status) {
+          return status < 500;
+        }
+      })
       .then(res => {
         setData(res.data);
-        setErrors([]);
+        if (res.status === 500) {
+          setErrors([
+            {
+              content: "INTERNAL_SEWRVER_ERROR"
+            }
+          ]);
+        } else {
+          switch (res.data) {
+            case "SUCCESS":
+              setErrors([]);
+              break;
+            default:
+              // APIから返ってくるメッセージが予想外なパターン
+              setErrors([
+                {
+                  content: "UNEXPECTED_ERROR"
+                }
+              ]);
+              break;
+          }
+        }
       })
       .catch(e => {
         console.log(e);

--- a/mosakin-frontend/src/hooks/usePaidList.ts
+++ b/mosakin-frontend/src/hooks/usePaidList.ts
@@ -5,6 +5,7 @@ import {
   PaidListHeaderViewModel,
   PaidListRowViewModel
 } from "../models/models/paidList";
+import { ErrorObject } from "@/models/models/error";
 import { useState, useEffect } from "react";
 import { axios } from "@/common/api/axios";
 
@@ -17,11 +18,23 @@ export const usePaidList = (): LoadableViewModel<PaidListViewModel> => {
     list: PaidListItem[];
     header: PaidListHeaderViewModel;
   }>();
+  const [errors, setErrors] = useState<ErrorObject[]>([]);
 
   useEffect(() => {
-    axios.get("/list").then(res => {
-      setData(res.data);
-    });
+    axios
+      .get("/list")
+      .then(res => {
+        setData(res.data);
+        setErrors([]);
+      })
+      .catch(e => {
+        console.log(e);
+        setErrors([
+          {
+            content: "UNEXPECTED_ERROR"
+          }
+        ]);
+      });
   }, []);
 
   return data
@@ -40,7 +53,8 @@ export const usePaidList = (): LoadableViewModel<PaidListViewModel> => {
                 console.log("edit", item);
               }
             }
-          }))
+          })),
+          errors
         }
       }
     : {

--- a/mosakin-frontend/src/hooks/useUpdatePaid.ts
+++ b/mosakin-frontend/src/hooks/useUpdatePaid.ts
@@ -30,42 +30,57 @@ export const useUpdatePaid = (): UpdatePaidViewModel => {
   };
   const onSubmit = () => {
     axios
-      .post(`/update`, {
-        paidId: updateData.paidId,
-        beforeAcquisitionDate: updateData.beforeAcquisitionDate,
-        paidAcquisitionDate: updateData.dateValue,
-        beforePaidTimeType: updateData.beforePaidTimeType,
-        paidTimeType: paidTimeValue,
-        paidReason: reasonValue
-      })
+      .post(
+        `/update`,
+        {
+          paidId: updateData.paidId,
+          beforeAcquisitionDate: updateData.beforeAcquisitionDate,
+          paidAcquisitionDate: updateData.dateValue,
+          beforePaidTimeType: updateData.beforePaidTimeType,
+          paidTimeType: paidTimeValue,
+          paidReason: reasonValue
+        },
+        {
+          validateStatus: function(status) {
+            return status < 500;
+          }
+        }
+      )
       .then(res => {
-        console.log(res);
-        switch (res.data) {
-          case "SUCCESS":
-            setErrors([]);
-            break;
-          case "DUPLICATED":
-            setErrors([
-              {
-                content: "DUPLICATED"
-              }
-            ]);
-            break;
-          case "NOTIFICATION_FAILED":
-            setErrors([
-              {
-                content: "NOTIFICATION_FAILED"
-              }
-            ]);
-            break;
-          default:
-            // APIから返ってくるメッセージが予想外なパターン
-            setErrors([
-              {
-                content: "UNEXPECTED_ERROR"
-              }
-            ]);
-            break;
+        if (res.status === 500) {
+          setErrors([
+            {
+              content: "INTERNAL_SEWRVER_ERROR"
+            }
+          ]);
+        } else {
+          switch (res.data) {
+            case "SUCCESS":
+              setErrors([]);
+              break;
+            case "DUPLICATED":
+              setErrors([
+                {
+                  content: "DUPLICATED"
+                }
+              ]);
+              break;
+            case "NOTIFICATION_FAILED":
+              setErrors([
+                {
+                  content: "NOTIFICATION_FAILED"
+                }
+              ]);
+              break;
+            default:
+              // APIから返ってくるメッセージが予想外なパターン
+              setErrors([
+                {
+                  content: "UNEXPECTED_ERROR"
+                }
+              ]);
+              break;
+          }
         }
       })
       .catch(e => {

--- a/mosakin-frontend/src/hooks/useUpdatePaid.ts
+++ b/mosakin-frontend/src/hooks/useUpdatePaid.ts
@@ -2,44 +2,80 @@ import {
   UpdatePaidViewModel,
   UpdatePaidItem
 } from "../models/models/UpdatePaid";
+import { ErrorObject } from "@/models/models/error";
 import { useState } from "react";
 import { axios } from "@/common/api/axios";
+import { useLoginInfo } from "@/context/LoginContext";
+import { usePaidInfo } from "@/context/PaidContext";
 
 export const useUpdatePaid = (): UpdatePaidViewModel => {
-  // TODO どう前画面からデータをうけとるか
-  const paidId = "1";
-  const userName = "芳賀樹生";
-  const beforeValue = "2019-07-22";
-  const beforePaidTimeValue = "ALL_DAY";
-  const [dateValue, dateSetValue] = useState("2019-07-22");
-  const [paidTimeValue, paidTimeOnChange] = useState("ALL_DAY");
-  const [reasonValue, reasonSetValue] = useState("データを更新するよ");
+  const [dateValue, dateSetValue] = useState("");
+  const [paidTimeValue, paidTimeOnChange] = useState("");
+  const [reasonValue, reasonSetValue] = useState("");
+  const [errors, setErrors] = useState<ErrorObject[]>([]);
+  const user = useLoginInfo();
+  const paid = usePaidInfo();
   const updateData: UpdatePaidItem = {
-    paidId: paidId,
-    userName: userName,
-    beforeValue: beforeValue,
+    paidId: paid.paidId,
+    userName: user.user.name,
+    beforeAcquisitionDate: paid.paidAcquisitionDate,
     dateValue: dateValue,
     dateOnChange: dateSetValue,
-    beforePaidTimeValue: beforePaidTimeValue,
+    beforePaidTimeType: paid.paidTimeType,
     paidTimeValue: paidTimeValue,
     paidTimeOnChange: paidTimeOnChange,
     reasonValue: reasonValue,
     reasonOnChange: reasonSetValue,
-    adminFlg: true
+    adminFlg: user.user.role === "ADMIN"
   };
   const onSubmit = () => {
     axios
       .post(`/update`, {
         paidId: updateData.paidId,
-        beforeAcquisitionDate: updateData.beforeValue,
+        beforeAcquisitionDate: updateData.beforeAcquisitionDate,
         paidAcquisitionDate: updateData.dateValue,
-        beforePaidTimeType: updateData.beforePaidTimeValue,
+        beforePaidTimeType: updateData.beforePaidTimeType,
         paidTimeType: paidTimeValue,
         paidReason: reasonValue
       })
       .then(res => {
         console.log(res);
+        switch (res.data) {
+          case "SUCCESS":
+            setErrors([]);
+            break;
+          case "DUPLICATED":
+            setErrors([
+              {
+                content: "DUPLICATED"
+              }
+            ]);
+            break;
+          case "NOTIFICATION_FAILED":
+            setErrors([
+              {
+                content: "NOTIFICATION_FAILED"
+              }
+            ]);
+            break;
+          default:
+            // APIから返ってくるメッセージが予想外なパターン
+            setErrors([
+              {
+                content: "UNEXPECTED_ERROR"
+              }
+            ]);
+            break;
+        }
+      })
+      .catch(e => {
+        console.log(e);
+        setErrors([
+          {
+            content: "UNEXPECTED_ERROR"
+          }
+        ]);
       });
   };
-  return { data: updateData, onSubmit: onSubmit };
+  return { data: updateData, onSubmit: onSubmit, errors };
 };

--- a/mosakin-frontend/src/models/models/UpdatePaid.ts
+++ b/mosakin-frontend/src/models/models/UpdatePaid.ts
@@ -1,17 +1,19 @@
 import { DateValue } from "./common";
+import { ErrorObject } from "@/models/models/error";
 
 export interface UpdatePaidViewModel {
   data: UpdatePaidItem;
   onSubmit: () => void;
+  errors: ErrorObject[];
 }
 
 export interface UpdatePaidItem {
   paidId: string;
   userName?: string;
-  beforeValue: DateValue;
+  beforeAcquisitionDate: DateValue;
   dateValue: DateValue;
   dateOnChange: (value: string) => void;
-  beforePaidTimeValue: string;
+  beforePaidTimeType: string;
   paidTimeValue: string;
   paidTimeOnChange: (value: string) => void;
   reasonValue: string;

--- a/mosakin-frontend/src/models/models/paidList/index.ts
+++ b/mosakin-frontend/src/models/models/paidList/index.ts
@@ -1,8 +1,10 @@
 import { DateValue, PaidTimeType } from "../common";
+import { ErrorObject } from "../error";
 
 export interface PaidListViewModel {
   list: PaidListRowViewModel[];
   header: PaidListHeaderViewModel;
+  errors: ErrorObject[];
 }
 
 export interface PaidListRowViewModel {


### PR DESCRIPTION
- 各テンプレートにエラーボックスコンポーネントの追加（マージンもテンプレごとに追加）

- 削除と管理者画面は別で対応します

- paid contextの追加

- providerの追加（未）

- first-child -> first-of-type (エラー解消)