### PR TITLE
#248

### DIFF
--- a/mosakin-frontend/src/components/atoms/button/index.tsx
+++ b/mosakin-frontend/src/components/atoms/button/index.tsx
@@ -21,6 +21,7 @@ const StyledButton = styled.button<ButtonProps>`
   border-radius: 10px;
   background-color: ${({ backgroundColor }) =>
     paletteDict[Constant.ButtonBackColor[backgroundColor]]};
+  z-index: 0;
   &:hover {
     transition-duration: 0.5s;
     &::before {

--- a/mosakin-frontend/src/components/molecules/header/index.tsx
+++ b/mosakin-frontend/src/components/molecules/header/index.tsx
@@ -13,6 +13,7 @@ export const HeaderWrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   line-height: 0;
+  z-index: 1000;
   @media (max-width: ${bp}) {
     height: 80px;
     padding-left: 4px;

--- a/mosakin-frontend/src/components/organisms/pc-navigation-bar/index.stories.tsx
+++ b/mosakin-frontend/src/components/organisms/pc-navigation-bar/index.stories.tsx
@@ -3,40 +3,25 @@ import { MemoryRouter as Router, Route, Switch } from "react-router-dom";
 import { storiesOf } from "@storybook/react";
 import { PcNavigationBar } from "./index";
 
-//TODO: 文字被らないようにするには
 storiesOf("organisms/NavigationBar", module).add("PcNavigationBar", () => {
   const A = () => {
     return (
       <>
-        <p>
-          <br />
-          <br />
-          <br />
-          <br />
-          新規申請がくるよ
-        </p>
+        <p>新規申請</p>
       </>
     );
   };
   const B = () => {
     return (
       <>
-        <br />
-        <br />
-        <br />
-        <br />
-        <p>有給取得一覧がくるよ</p>
+        <p>有給取得一覧</p>
       </>
     );
   };
   const C = () => {
     return (
       <>
-        <br />
-        <br />
-        <br />
-        <br />
-        <p>全ユーザ有給取得一覧がくるよ</p>
+        <p>全ユーザ有給取得一覧</p>
       </>
     );
   };
@@ -46,21 +31,24 @@ storiesOf("organisms/NavigationBar", module).add("PcNavigationBar", () => {
         <PcNavigationBar
           menus={[
             {
-              id: "a",
+              manuId: "a",
               menuItem: "新規申請",
               iconName: "pen"
             },
             {
-              id: "b",
+              manuId: "b",
               menuItem: "有給取得一覧",
               iconName: "file"
-            },
-            {
-              id: "c",
-              menuItem: "(全)有給取得一覧",
-              iconName: "folder"
             }
           ]}
+          adminMenus={[
+            {
+              adminMenuId: "c",
+              adminMenuItem: "(全)有給取得一覧",
+              adminIconName: "folder"
+            }
+          ]}
+          adminFlg={"COMMON"}
         />
         <Switch>
           <Route path="/a" component={A} />
@@ -72,3 +60,64 @@ storiesOf("organisms/NavigationBar", module).add("PcNavigationBar", () => {
     </>
   );
 });
+
+storiesOf("organisms/NavigationBar", module).add(
+  "PcNavigationBar(admin)",
+  () => {
+    const A = () => {
+      return (
+        <>
+          <p>新規申請</p>
+        </>
+      );
+    };
+    const B = () => {
+      return (
+        <>
+          <p>有給取得</p>
+        </>
+      );
+    };
+    const C = () => {
+      return (
+        <>
+          <p>全ユーザ有給取得一覧</p>
+        </>
+      );
+    };
+    return (
+      <>
+        <Router>
+          <PcNavigationBar
+            menus={[
+              {
+                manuId: "a",
+                menuItem: "新規申請",
+                iconName: "pen"
+              },
+              {
+                manuId: "b",
+                menuItem: "有給取得一覧",
+                iconName: "file"
+              }
+            ]}
+            adminMenus={[
+              {
+                adminMenuId: "c",
+                adminMenuItem: "(全)有給取得一覧",
+                adminIconName: "folder"
+              }
+            ]}
+            adminFlg={"ADMIN"}
+          />
+          <Switch>
+            <Route path="/a" component={A} />
+            <Route path="/b" component={B} />
+            <Route path="/c" component={C} />
+          </Switch>
+        </Router>
+        spモードにしたら消えます
+      </>
+    );
+  }
+);

--- a/mosakin-frontend/src/components/organisms/pc-navigation-bar/index.tsx
+++ b/mosakin-frontend/src/components/organisms/pc-navigation-bar/index.tsx
@@ -6,31 +6,55 @@ import { Logo } from "@/components/atoms/logo";
 import { UserIcon } from "@/components/atoms/userIcon";
 import { IconList } from "@/components/atoms/icon/constant";
 import { HeaderWrapper } from "@/components/molecules/header";
-import { NavigationMenu } from "@/components/molecules/navigation-menu/index";
+import { NavigationMenu } from "@/components/molecules/navigation-menu";
 import {
   PullDownWrapper,
   PullDownUser,
   PullDownMenuList
 } from "@/components/molecules/pull-down-menu";
+import { UserRole } from "@/models/models/User";
 
 type MenuProps = {
   menus: Menu[];
+  adminMenus: AdminMenu[];
+  adminFlg: UserRole;
 };
 
-type Menu = {
-  id: string;
+export type Menu = {
+  manuId: string;
   menuItem: string;
   iconName: IconList;
 };
 
-export const PcNavigationBar: React.FC<MenuProps> = ({ menus }) => {
+export type AdminMenu = {
+  adminMenuId: string;
+  adminMenuItem: string;
+  adminIconName: IconList;
+};
+
+export const PcNavigationBar: React.FC<MenuProps> = ({
+  menus,
+  adminMenus,
+  adminFlg
+}) => {
   const menuItemList = menus.map((menu: Menu) => (
-    <StyledList key={menu.id}>
-      <StyledLink to={`/${menu.id}`}>
+    <StyledList key={menu.manuId}>
+      <StyledLink to={`/${menu.manuId}`}>
         <NavigationMenu
-          key={menu.id}
+          key={menu.manuId}
           value={menu.menuItem}
           name={menu.iconName}
+        />
+      </StyledLink>
+    </StyledList>
+  ));
+  const adminMenuItemList = adminMenus.map((adminMenu: AdminMenu) => (
+    <StyledList key={adminMenu.adminMenuId}>
+      <StyledLink to={`/${adminMenu.adminMenuId}`}>
+        <NavigationMenu
+          key={adminMenu.adminMenuId}
+          value={adminMenu.adminMenuItem}
+          name={adminMenu.adminIconName}
         />
       </StyledLink>
     </StyledList>
@@ -42,6 +66,7 @@ export const PcNavigationBar: React.FC<MenuProps> = ({ menus }) => {
         <HeaderWrapper>
           <Logo />
           {menuItemList}
+          {adminFlg === "ADMIN" && <>{adminMenuItemList}</>}
           <UserIconWrapper onClick={() => setShow(!show)}>
             <UserIcon />
           </UserIconWrapper>
@@ -53,6 +78,7 @@ export const PcNavigationBar: React.FC<MenuProps> = ({ menus }) => {
 };
 
 const PcNavigationBarWrapper = styled.div`
+  padding-bottom: 70px;
   @media (max-width: ${bp}) {
     display: none;
   }

--- a/mosakin-frontend/src/components/organisms/sp-header/index.stories.tsx
+++ b/mosakin-frontend/src/components/organisms/sp-header/index.stories.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { SpHeader } from "./index";
+
+storiesOf("organisms/Header", module).add("SpHeader", () => (
+  <>
+    <SpHeader />
+    <p>spモードにしたらでてくる</p>
+  </>
+));

--- a/mosakin-frontend/src/components/organisms/sp-header/index.tsx
+++ b/mosakin-frontend/src/components/organisms/sp-header/index.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { bp } from "@/common/theme";
+import { HeaderWrapper } from "@/components/molecules/header";
+import { UserIcon } from "@/components/atoms/userIcon";
+import { Logo } from "@/components/atoms/logo";
+
+export const SpHeader = () => (
+  <SpHeaderWrapper>
+    <HeaderWrapper>
+      <Logo />
+      <UserIcon />
+    </HeaderWrapper>
+  </SpHeaderWrapper>
+);
+
+const SpHeaderWrapper = styled.div`
+  display: none;
+  @media (max-width: ${bp}) {
+    display: block;
+    padding-bottom: 80px;
+  }
+`;

--- a/mosakin-frontend/src/components/organisms/sp-navigation-bar/index.stories.tsx
+++ b/mosakin-frontend/src/components/organisms/sp-navigation-bar/index.stories.tsx
@@ -7,21 +7,21 @@ storiesOf("organisms/NavigationBar", module).add("SpNavigationBar", () => {
   const A = () => {
     return (
       <>
-        <p>新規申請がくるよ</p>
+        <p>新規申請</p>
       </>
     );
   };
   const B = () => {
     return (
       <>
-        <p>有給取得一覧がくるよ</p>
+        <p>有給取得一覧</p>
       </>
     );
   };
   const C = () => {
     return (
       <>
-        <p>全ユーザ有給取得一覧がくるよ</p>
+        <p>全ユーザ有給取得一覧</p>
       </>
     );
   };
@@ -32,21 +32,24 @@ storiesOf("organisms/NavigationBar", module).add("SpNavigationBar", () => {
         <SpNavigationBar
           menus={[
             {
-              id: "a",
+              manuId: "a",
               menuItem: "新規申請",
               iconName: "pen"
             },
             {
-              id: "b",
+              manuId: "b",
               menuItem: "有給取得一覧",
               iconName: "file"
-            },
-            {
-              id: "c",
-              menuItem: "(全)有給取得一覧",
-              iconName: "folder"
             }
           ]}
+          adminMenus={[
+            {
+              adminMenuId: "c",
+              adminMenuItem: "(全)有給取得一覧",
+              adminIconName: "folder"
+            }
+          ]}
+          adminFlg={"COMMON"}
         />
         <Switch>
           <Route path="/a" component={A} />
@@ -57,3 +60,64 @@ storiesOf("organisms/NavigationBar", module).add("SpNavigationBar", () => {
     </>
   );
 });
+
+storiesOf("organisms/NavigationBar", module).add(
+  "SpNavigationBar(admin)",
+  () => {
+    const A = () => {
+      return (
+        <>
+          <p>新規申請</p>
+        </>
+      );
+    };
+    const B = () => {
+      return (
+        <>
+          <p>有給取得一覧</p>
+        </>
+      );
+    };
+    const C = () => {
+      return (
+        <>
+          <p>全ユーザ有給取得一覧</p>
+        </>
+      );
+    };
+    return (
+      <>
+        spモードにしたら出てきます
+        <Router>
+          <SpNavigationBar
+            menus={[
+              {
+                manuId: "a",
+                menuItem: "新規申請",
+                iconName: "pen"
+              },
+              {
+                manuId: "b",
+                menuItem: "有給取得一覧",
+                iconName: "file"
+              }
+            ]}
+            adminMenus={[
+              {
+                adminMenuId: "c",
+                adminMenuItem: "(全)有給取得一覧",
+                adminIconName: "folder"
+              }
+            ]}
+            adminFlg={"ADMIN"}
+          />
+          <Switch>
+            <Route path="/a" component={A} />
+            <Route path="/b" component={B} />
+            <Route path="/c" component={C} />
+          </Switch>
+        </Router>
+      </>
+    );
+  }
+);

--- a/mosakin-frontend/src/components/organisms/sp-navigation-bar/index.tsx
+++ b/mosakin-frontend/src/components/organisms/sp-navigation-bar/index.tsx
@@ -4,32 +4,59 @@ import { Link } from "react-router-dom";
 import { paletteDict, bp } from "@/common/theme";
 import { NavigationMenu } from "@/components/molecules/navigation-menu/index";
 import { IconList } from "@/components/atoms/icon/constant";
+import { UserRole } from "@/models/models/User";
 
 type MenuProps = {
   menus: Menu[];
+  adminMenus: AdminMenu[];
+  adminFlg: UserRole;
 };
 
 type Menu = {
-  id: string;
+  manuId: string;
   menuItem: string;
   iconName: IconList;
 };
 
-export const SpNavigationBar: React.FC<MenuProps> = ({ menus }) => {
+type AdminMenu = {
+  adminMenuId: string;
+  adminMenuItem: string;
+  adminIconName: IconList;
+};
+
+export const SpNavigationBar: React.FC<MenuProps> = ({
+  menus,
+  adminMenus,
+  adminFlg
+}) => {
   const menuItemList = menus.map((menu: Menu) => (
-    <StyledList key={menu.id}>
-      <StyledLink to={`/${menu.id}`}>
+    <StyledList key={menu.manuId}>
+      <StyledLink to={`/${menu.manuId}`}>
         <NavigationMenu
-          key={menu.id}
+          key={menu.manuId}
           value={menu.menuItem}
           name={menu.iconName}
         />
       </StyledLink>
     </StyledList>
   ));
+  const adminMenuItemList = adminMenus.map((adminMenu: AdminMenu) => (
+    <StyledList key={adminMenu.adminMenuId}>
+      <StyledLink to={`/${adminMenu.adminMenuId}`}>
+        <NavigationMenu
+          key={adminMenu.adminMenuId}
+          value={adminMenu.adminMenuItem}
+          name={adminMenu.adminIconName}
+        />
+      </StyledLink>
+    </StyledList>
+  ));
   return (
     <ul>
-      <SpNavigationBarWrapper>{menuItemList}</SpNavigationBarWrapper>
+      <SpNavigationBarWrapper>
+        {menuItemList}
+        {adminFlg === "ADMIN" && <>{adminMenuItemList}</>}
+      </SpNavigationBarWrapper>
     </ul>
   );
 };
@@ -61,5 +88,6 @@ const SpNavigationBarWrapper = styled.div`
     justify-content: space-between;
     line-height: 0;
     bottom: 0;
+    z-index: 1000;
   }
 `;

--- a/mosakin-frontend/src/components/pages/Layout.tsx
+++ b/mosakin-frontend/src/components/pages/Layout.tsx
@@ -1,21 +1,15 @@
 import React from "react";
-import { Logo } from "../atoms/logo";
-import styled from "@emotion/styled";
-import { paletteDict } from "@/common/theme";
 import { useLoginInfo } from "@/context/LoginContext";
 import { Button } from "../atoms/button";
 import { Text } from "../atoms/text";
 import { User } from "@/models/models/User";
-
-const HeaderFixme = () => (
-  <IconBackColor>
-    <Logo></Logo>
-  </IconBackColor>
-);
-
-const IconBackColor = styled.div`
-  background-color: ${paletteDict.base};
-`;
+import {
+  PcNavigationBar,
+  Menu,
+  AdminMenu
+} from "@/components/organisms/pc-navigation-bar";
+import { SpNavigationBar } from "@/components/organisms/sp-navigation-bar";
+import { SpHeader } from "@/components/organisms/sp-header";
 
 export const Layout: React.FC = ({ children }) => {
   const loginstatus = useLoginInfo();
@@ -36,9 +30,38 @@ interface LayoutHeaderProps {
 }
 
 const LayoutHeader: React.FC<LayoutHeaderProps> = ({ user, onLogoutClick }) => {
+  const menus: Menu[] = [
+    {
+      manuId: "new",
+      menuItem: "新規申請",
+      iconName: "pen"
+    },
+    {
+      manuId: "update",
+      menuItem: "有給取得一覧",
+      iconName: "file"
+    }
+  ];
+  const adminMenus: AdminMenu[] = [
+    {
+      adminMenuId: "admin",
+      adminMenuItem: "(全)有給取得一覧",
+      adminIconName: "folder"
+    }
+  ];
   return (
     <>
-      <HeaderFixme></HeaderFixme>
+      <PcNavigationBar
+        menus={menus}
+        adminMenus={adminMenus}
+        adminFlg={user.role}
+      />
+      <SpHeader />
+      <SpNavigationBar
+        menus={menus}
+        adminMenus={adminMenus}
+        adminFlg={user.role}
+      />
       <Button
         onClick={onLogoutClick}
         backgroundColor="1"


### PR DESCRIPTION
- ユーザー権限ごとに適切な共通ヘッダー（フッター）を表示する
- 共通ヘッダー（フッター）からページ遷移を行うことができる

（なんか問題あったらごめんなさい😧）